### PR TITLE
🔧 Fix: Ajout de l'installation de twine dans le workflow deploy

### DIFF
--- a/.github/workflows/ci-matrix.yml
+++ b/.github/workflows/ci-matrix.yml
@@ -255,6 +255,11 @@ jobs:
           name: dist
           path: dist/
 
+      - name: "Install Twine"
+        run: |
+          python -m pip install --upgrade pip
+          pip install twine
+
       - name: "Publish to PyPI"
         run: |
           echo "${{ secrets.PYPI_API_TOKEN }}" | twine upload dist/*


### PR DESCRIPTION
- Installation de twine avant l'upload PyPI
- Correction de l'erreur 'twine: command not found'
- Workflow deploy maintenant fonctionnel 🚀