### PR TITLE
🎯 Fix: Résolution finale des métadonnées PyPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["flit-core>=3.8.0"]
+requires = ["flit-core>=3.9.0"]
 build-backend = "flit_core.buildapi"
 
 [project]
@@ -68,6 +68,9 @@ Issues = "https://github.com/arkalia-luna-system/arkalia-metrics-collector/issue
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.setuptools]
+include-package-data = true
 
 # Configuration Black (formatage)
 [tool.black]


### PR DESCRIPTION
- Mise à jour flit-core vers 3.9+ (métadonnées compatibles)
- Plus d'erreur 'license-expression' ou 'license-file'
- Build et validation twine fonctionnels ✅
- Prêt pour le déploiement automatique via GitHub Actions 🚀