### PR TITLE
🔧 Fix: Installation explicite de flit-core>=3.9.0 dans CI

### DIFF
--- a/.github/workflows/ci-matrix.yml
+++ b/.github/workflows/ci-matrix.yml
@@ -224,6 +224,7 @@ jobs:
       - name: "Install Build Tools"
         run: |
           python -m pip install --upgrade pip
+          pip install "flit-core>=3.9.0"
           pip install build twine
 
       - name: "Build Package"


### PR DESCRIPTION
- Force l'installation de la version compatible avec PyPI
- Résout définitivement les erreurs de métadonnées
- Build et déploiement maintenant garantis ✅