### PR TITLE
🎯 Fix: Configuration licence corrigée pour PyPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "arkalia-metrics-collector"
 version = "1.0.0"
 description = "Professional metrics collection and analysis for Python projects"
 readme = "README.md"
-license = "MIT"
+license = {text = "MIT"}
 authors = [
     {name = "Arkalia Luna System", email = "contact@arkalia-luna.com"}
 ]


### PR DESCRIPTION
- Changé 'license = "MIT"' vers 'license = {text = "MIT"}'
- Résout définitivement les erreurs de métadonnées
- Plus d'erreur 'license-file' ou 'license-expression'
- Build, validation et upload maintenant fonctionnels ✅
- Prêt pour le déploiement automatique ! 🚀